### PR TITLE
Log the URLS we're using

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -89,12 +89,15 @@ async function validateCanvasUrl(canvasUrl, canvasToken) {
  */
 const validateConfig = () => {
     try {
-        checkDefined('canvas_url')
+        const canvasUrl = checkDefined('canvas_url')
         checkDefined('canvas_token')
 
-        checkDefined('tool_support_url')
+        const toolSupportUrl = checkDefined('tool_support_url')
         checkDefined('tool_support_username')
         checkDefined('tool_support_password')
+        
+        console.log(`Canvas URL: ${canvasUrl}`)
+        console.log(`Tool Support URL: ${toolSupportUrl}`)
     } catch (e) {
         console.error('Configuration missing, please run `init`:' + e.message)
         process.exit(1)
@@ -106,6 +109,7 @@ const checkDefined = (key) => {
     if (!value) {
         throw new Error(`Error: ${key} is not defined`)
     }
+    return value
 }
 
 /**
@@ -248,7 +252,6 @@ program
     .description('Set additional values needed for this tool.')
     .option('-t, --template <template>', 'template to use', './tool-config/tool-config.json')
     .action((options) => {
-        validateConfig()
         let jsonTemplate
         try {
             jsonTemplate = fs.readFileSync(options.template, 'utf8');


### PR DESCRIPTION
It's helpful to always log the URLs we're connecting to as it's easy to be configuring a tool against the wrong canvas/tool-support instance.

Also we don't need to validate the config when running the setup command as it doesn't use any remote servers.