### PR TITLE
Add -S option for env in shebang

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 // Get process vars set before import
 import '../lib/setup.js'


### PR DESCRIPTION
This is needed for v2 to work with the GNU version of env.  It is needed because the --no-warnings flag is passed to node.
Without the -S option, this error appears:
```
$ npx @oxctl/lti-auto-configuration@2
/usr/bin/env: ‘node --no-warnings’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```
From the manual of GNU env:
```
-S, --split-string=S
          process and split S into separate arguments; used to pass multiple arguments on shebang lines
```

Running lti-auto-configuration locally, this fix worked for me.

> [!IMPORTANT]  
> We should test though, that with using this option does not break lti-auto-configuration on other systems!