### PR TITLE
Simpler way of loading current version

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,11 +1,9 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 // Get process vars set before import
 import '../lib/setup.js'
 import config from 'config'
 import promptSync from 'prompt-sync'
-// This is so that we don't have the version in multiple places.
-import packageJson from '../package.json' assert {type: 'json'}
 import {program} from 'commander';
 import fs from 'node:fs'
 import toolSupportCreate from '../lib/tool-support.js'
@@ -191,7 +189,9 @@ const configValue = (key) => {
 
 program
     .name('index.js')
-    .version(packageJson.version)
+    // This is only defined when running through npm (npx) and not when running directly
+    // Using JSON imports is tool broken to support well across node versions.
+    .version(process.env.npm_package_version || 'unknown')
     .description('Contains a set of CLI tools to auto-provision LTI tools to Canvas')
 
 program


### PR DESCRIPTION
Rather than doing JSON imports we just use the npm package version from the environment. This isn't set if you run the file directly, but then you're probably developing, so it's not as important to report a good version.