### PR TITLE
Don't require a configuration file for deletes.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -260,7 +260,7 @@ program
             process.exit(1)
         }
         // Just need this while replacing values, these are the default values.
-        const templateConfig = JSON.parse(jsonTemplate).config
+        const templateConfig = JSON.parse(jsonTemplate).config || {}
 
         const localConfig = {}
 


### PR DESCRIPTION
When performing a delete it's enough to pass in the LTI registration ID and nothing else so rather than failing when the local tool-config file can't be found we just ignore it instead.