### PR TITLE
Allow external tool details to be looked up.

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -143,8 +143,29 @@ export default function create(canvasUrl, canvasToken) {
                 });
         },
 
+        getLtiTools: async (canvasAccountId) => {
+            const getLtiToolUrl = CANVAS_ADD_EXTERNAL_TOOL_API_URL.replace(ACCOUNT_ID, canvasAccountId);
+
+            const loadBatch = async (url) => {
+                try {
+                    const response = await axios.get(url, REQUEST_CONFIG);
+                    const link = parse(response.headers.get('link'))
+                    let items = []
+                    if (link && link.next && link.next.url) {
+                        let nextUrl = link.next.url
+                        items = await loadBatch(nextUrl, response.data)
+                    }
+                    return [...response.data, ...items]
+                } catch (error) {
+                    checkError(error)
+                    throw new Error(`Error getting LTI tools in sub-account ${canvasAccountId}: ${error}`);
+                }
+            }
+            return loadBatch(`${canvasUrl}${getLtiToolUrl}`);
+        },
+
         // Method to add the created LTI tool to the supplied subaccount.
-        addLtiToolToTestingSubaccount: async (developerKeyId, canvasAccountId) => {
+        addLtiToolToSubaccount: async (developerKeyId, canvasAccountId) => {
 
             const addLtiToolUrl = CANVAS_ADD_EXTERNAL_TOOL_API_URL.replace(ACCOUNT_ID, canvasAccountId);
 
@@ -160,7 +181,7 @@ export default function create(canvasUrl, canvasToken) {
                 })
                 .catch(function (error) {
                     checkError(error)
-                    throw new Error(`Error adding the LTI tool ${developerKeyId} to the testing subaccount ${canvasAccountId} ${error}`);
+                    throw new Error(`Error adding the LTI tool ${developerKeyId} to sub-account ${canvasAccountId}: ${error}`);
                 });
         }
     }


### PR DESCRIPTION
This allows the LTI tool JSON for a registration ID to be looked up.

It also checks that a tool is installed in the sub-account when updating the configuration and if it isn't adds it.

The validate command also now checks to see that the developer key is added to the sub-account.