### PR TITLE
Allow value to be empty.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -245,7 +245,8 @@ program
                     return match;
                 }
                 const value = lookupValue(name)
-                if (!value) {
+                // undefined and not zero length string
+                if (!value && value !== '') {
                     throw new Error(`No values defined for ${name}`)
                 }
                 return value
@@ -443,7 +444,8 @@ program
                 return match;
             }
             const value = lookupValue(name)
-            if (!value) {
+            // undefined and not zero length string
+            if (!value && value !== '') {
                 throw new Error(`No values defined for ${name}`)
             }
             return value


### PR DESCRIPTION
For some values we want to allow empty values and only reject undefined values. An example of this is the `title_suffix` where for all instances apart from production we append something onto the name of the tool to make it easier to identify, but in production we append an empty string.