### PR TITLE
Add permissions to GitHub Actions

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "v*.*.*"
 
+# Default permissions for all jobs
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -23,6 +27,8 @@ jobs:
   release:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This improves the security of GitHub actions by restricting what things can be performed by GitHub Actions.