### PR TITLE
Allow the tool to not be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ git push && git push --tags
 
 ## Disabling adding tool to sub-account
 
-If you don't want a tool to be added to a sub-account you can set the `canvas_account_id` configuratino to `none`. This can be useful when initially releasing a tool to a production instance and you wish to have more control over when end users see it.
-
+If you don't want a tool to be added to a sub-account you can set the `canvas_account_id` configuration to `none`. This can be useful when initially releasing a tool to a production instance and you wish to have more control over when end users see it.
 ## Automatic Variables
 
 The following variables are automatically set by the tool and can be used in the configuration:

--- a/README.md
+++ b/README.md
@@ -189,3 +189,20 @@ Bumping up the version with `npm version` and pushing those changes should resul
 npm version patch
 git push && git push --tags
 ```
+
+# Notes
+
+## Disabling adding tool to sub-account
+
+If you don't want a tool to be added to a sub-account you can set the `canvas_account_id` configuratino to `none`. This can be useful when initially releasing a tool to a production instance and you wish to have more control over when end users see it.
+
+## Automatic Variables
+
+The following variables are automatically set by the tool and can be used in the configuration:
+
+ - `canvas_provider_url` - The URL of the LTI 1.3 initation endpoint for the Canvas instance.
+ - ``
+ - `lti_dev_id` - The LTI developer key Client ID.
+ - `lti_dev_key` - The LTI developer key Client secret.
+ - `api_dev_id` - The API developer key Client ID.
+ - `api_dev_key` - The API developer key Client secret.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ If you don't want a tool to be added to a sub-account you can set the `canvas_ac
 The following variables are automatically set by the tool and can be used in the configuration:
 
  - `canvas_provider_url` - The URL of the LTI 1.3 initation endpoint for the Canvas instance.
- - ``
  - `lti_dev_id` - The LTI developer key Client ID.
  - `lti_dev_key` - The LTI developer key Client secret.
  - `api_dev_id` - The API developer key Client ID.

--- a/bin/index.js
+++ b/bin/index.js
@@ -344,8 +344,10 @@ program
 
 
             // Finally we just need to add the LTI tool to the testing subaccount
-            const externalTool = await canvas.addLtiToolToSubaccount(ltiDevId, canvasAccountId);
-            console.log(`LTI tool with id ${ltiDevId} added to the sub-account ${canvasAccountId} on ${canvasUrl}.`);
+            if (canvasAccountId !== 'none') {
+                await canvas.addLtiToolToSubaccount(ltiDevId, canvasAccountId);
+                console.log(`LTI tool with id ${ltiDevId} added to the sub-account ${canvasAccountId} on ${canvasUrl}.`);
+            }
         }
     )
 program
@@ -555,14 +557,16 @@ program
             console.log(`API developer key enabled with id ${apiDevId}`);
         }
 
-        const ltiTools = await canvas.getLtiTools(canvasAccountId);
-        const canvasLtiKeyId = ltiToolRegistration.lti.clientId;
-        // For local tools the external tools API uses the shorter ID.
-        const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
-        const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
-        if (!ltiTool) {
-            await canvas.addLtiToolToSubaccount(ltiDevId, canvasAccountId);
-            console.log(`LTI tool with id ${ltiDevId} added to the sub-account ${canvasAccountId} on ${canvasUrl}.`);
+        if (canvasAccountId !== 'none') {
+            const ltiTools = await canvas.getLtiTools(canvasAccountId);
+            const canvasLtiKeyId = ltiToolRegistration.lti.clientId;
+            // For local tools the external tools API uses the shorter ID.
+            const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
+            const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
+            if (!ltiTool) {
+                await canvas.addLtiToolToSubaccount(ltiDevId, canvasAccountId);
+                console.log(`LTI tool with id ${ltiDevId} added to the sub-account ${canvasAccountId} on ${canvasUrl}.`);
+            }
         }
     })
 
@@ -615,17 +619,18 @@ program
             const ltiKey = developerKeys.find(key => key.id === canvasLtiKeyId);
             if (ltiKey) {
                 console.log(`Found LTI developer key ${canvasLtiKeyId}`)
-                const ltiTools = await canvas.getLtiTools(canvasAccountId);
-                // For local tools the external tools API uses the shorter ID.
-                const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
-                const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
-                if (ltiTool) {
-                    console.info(`LTI tool ${ltiTool.id} found with developer key ${canvasLtiKeyId} in account ${canvasAccountId}`)
-                } else {
-                    console.warn(`Warning: Can't find LTI tool for developer key ${canvasLtiKeyId} in account ${canvasAccountId}`)
-                    hasError = true
+                if (canvasAccountId !== 'none') {
+                    const ltiTools = await canvas.getLtiTools(canvasAccountId);
+                    // For local tools the external tools API uses the shorter ID.
+                    const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
+                    const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
+                    if (ltiTool) {
+                        console.info(`LTI tool ${ltiTool.id} found with developer key ${canvasLtiKeyId} in account ${canvasAccountId}`)
+                    } else {
+                        console.warn(`Warning: Can't find LTI tool for developer key ${canvasLtiKeyId} in account ${canvasAccountId}`)
+                        hasError = true
+                    }
                 }
-                
             } else {
                 console.warn(`Warning: Can't find LTI developer key ${canvasLtiKeyId}`)
                 hasError = true
@@ -771,15 +776,20 @@ program
         const canvasLtiKeyId = ltiRegistration.lti.clientId
 
         const canvas = canvasCreate(canvasUrl, canvasToken)
-        const ltiTools = await canvas.getLtiTools(canvasAccountId)
-
-        // For local tools the external tools API uses the shorter ID.
-        const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
-        const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
-        if (ltiTool) {
-            console.info(JSON.stringify(ltiTool, null, 4))
+        if (canvasAccountId !== 'none') {
+            const ltiTools = await canvas.getLtiTools(canvasAccountId)
+            // For local tools the external tools API uses the shorter ID.
+            const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
+            const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
+            if (ltiTool) {
+                console.info(JSON.stringify(ltiTool, null, 4))
+            } else {
+                console.error(`Warning: Can't find LTI tool for developer key ${canvasLtiKeyId} in account ${canvasAccountId}`)
+                process.exit(1)
+            }
         } else {
-            console.error(`Warning: Can't find LTI tool for developer key ${canvasLtiKeyId} in account ${canvasAccountId}`)
+            // We need a sub-account to look up the tool in.
+            console.error(`No sub-account to lookup the LTI tool in.`)
             process.exit(1)
         }
     })


### PR DESCRIPTION
When deploying new tools you sometimes don't want the tool to be made available to users. This change allows the `canvas_account_id` to be set to `none` which causes it to no longer add or update the external tool.