### PR TITLE
Trim value returned from prompt

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -26,7 +26,9 @@ if (major < 18) {
 }
 
 // Allow ^C to interrupt
-const prompt = promptSync({sigint: true})
+const promptFunc = promptSync({sigint: true})
+// Always trim the input, so we don't have to worry about trailing spaces.
+const prompt = (message)=> promptFunc(message).trim()
 
 function shouldRetry() {
     const abort = prompt('Abort? [y/n] ')


### PR DESCRIPTION
This means we trim off all trailing whitespace when reading values.