### PR TITLE
npm config upgrade (Node 24 fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^1.8.2",
         "commander": "^11.0.0",
-        "config": "^3.3.9",
+        "config": "^4.1.1",
         "json-bigint": "^1.0.0",
         "parse-link-header": "^2.0.0",
         "prompt-sync": "^4.2.0"
@@ -72,14 +72,15 @@
       }
     },
     "node_modules/config": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.9.tgz",
-      "integrity": "sha512-G17nfe+cY7kR0wVpc49NCYvNtelm/pPy8czHoFkAgtV1lkmcp7DHtWCdDu+C9Z7gb2WVqa9Tm3uF9aKaPbCfhg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/config/-/config-4.1.1.tgz",
+      "integrity": "sha512-jljfwqNZ7QHwAW9Z9NDZdJARFiu5pjLqQO0K4ooY22iY/bIY78n0afI4ANEawfgQOxri0K/3oTayX8XIauWcLA==",
+      "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/delayed-stream": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "axios": "^1.8.2",
     "commander": "^11.0.0",
-    "config": "^3.3.9",
+    "config": "^4.1.1",
     "json-bigint": "^1.0.0",
     "parse-link-header": "^2.0.0",
     "prompt-sync": "^4.2.0"


### PR DESCRIPTION
The config package uses some methods that are no longer available in Node 24 and as a result lti-auto-configuration wouldn't work on Node 24. The upgrades the config package which fixes this.