### PR TITLE
Remove 'sign' property from tool-config.json

### DIFF
--- a/tool-config/tool-config.json
+++ b/tool-config/tool-config.json
@@ -104,7 +104,6 @@
     "origins": [
         "$LTI_TOOL_URL"
     ],
-    "sign": true,
     "secret": null,
     "issuer": "${LTI_SERVER_URL}",
     "nrpsAllowedRoles": []


### PR DESCRIPTION
This property isn't supported any more and doesn't need to be in the example file.