### PR TITLE
Unlock LTI registrations when adding to subaccount

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -49,6 +49,26 @@ const promptFunc = promptSync({sigint: true})
 // Always trim the input, so we don't have to worry about trailing spaces.
 const prompt = (message, value, opts)=> promptFunc(message, value, opts).trim()
 
+/**
+ * Gets the LTI registration ID by client ID and unlocks it.
+ */
+const unlockLtiRegistrationByClientId = async (canvas, clientId) => {
+    try {
+        const canvasLtiRegistration = await canvas.getLtiRegistrationByClientId(clientId);
+        const canvasLtiRegistrationId = canvasLtiRegistration.id;
+        try {
+            await canvas.unlockLtiDeveloperKey(canvasLtiRegistrationId);
+            console.log(`LTI registration unlocked with id ${canvasLtiRegistrationId}`);
+        } catch (error) {
+            console.error(`Failed to unlock LTI registration: ${error.message}`);
+            throw error;
+        }
+    } catch (error) {
+        console.error(`Failed to get or unlock LTI registration: ${error.message}`);
+        throw error;
+    }
+}
+
 function shouldRetry() {
     const abort = prompt('Abort? [y/n] ')
     if (abort === 'y' || abort === 'Y') {
@@ -358,6 +378,8 @@ program
 
             // Finally we just need to add the LTI tool to the testing subaccount
             if (canvasAccountId !== 'none') {
+                // Unlock the LTI registration before adding to subaccount
+                await unlockLtiRegistrationByClientId(canvas, ltiDevId);
                 await canvas.addLtiToolToSubaccount(ltiDevId, canvasAccountId);
                 console.log(`LTI tool with id ${ltiDevId} added to the sub-account ${canvasAccountId} on ${canvasUrl}.`);
             }
@@ -595,6 +617,8 @@ program
             const localKeyId = (BigInt(canvasLtiKeyId) % BigInt("10000000000000")).toString()
             const ltiTool = ltiTools.find(tool => tool.developer_key_id === localKeyId || tool.developer_key_id === canvasLtiKeyId);
             if (!ltiTool) {
+                // Unlock the LTI registration before adding to subaccount
+                await unlockLtiRegistrationByClientId(canvas, ltiDevId);
                 await canvas.addLtiToolToSubaccount(ltiDevId, canvasAccountId);
                 console.log(`LTI tool with id ${ltiDevId} added to the sub-account ${canvasAccountId} on ${canvasUrl}.`);
             }

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -12,6 +12,8 @@ const CANVAS_ENABLE_DEV_KEY_API_URL = `/api/v1/accounts/1/developer_keys/${DEV_K
 const CANVAS_ADD_EXTERNAL_TOOL_API_URL = `/api/v1/accounts/${ACCOUNT_ID}/external_tools`;
 const CANVAS_UPDATE_LTI_KEY_API_URL = `/api/lti/developer_keys/${DEV_KEY}/tool_configuration`;
 const CANVAS_UPDATE_API_KEY_API_URL = `/api/v1/developer_keys/${DEV_KEY}`;
+const CANVAS_UPDATE_LTI_REGISTRATION_API_URL = `/api/v1/accounts/1/lti_registrations/${DEV_KEY}`;
+const CANVAS_GET_LTI_REGISTRATION_BY_CLIENT_ID = `/api/v1/accounts/1/lti_registration_by_client_id/${DEV_KEY}`;
 
 
 // One limitation of the Canvas API for developer keys is there's no easy way to retrieve a single developer key
@@ -106,6 +108,25 @@ export default function create(canvasUrl, canvasToken) {
             }
         },
 
+        // Method to unlock an LTI registration
+        unlockLtiDeveloperKey: async (ltiRegistrationId) => {
+            const updateLtiRegistrationUrl = CANVAS_UPDATE_LTI_REGISTRATION_API_URL.replace(DEV_KEY, ltiRegistrationId);
+
+            const unlockBody = {
+                lock_deploying: false
+            };
+
+            // Unlock the LTI registration
+            return await axios.put(`${canvasUrl}${updateLtiRegistrationUrl}`, unlockBody, REQUEST_CONFIG)
+                .then(function (response) {
+                    return response.data;
+                })
+                .catch(function (error) {
+                    checkError(error)
+                    throw error;
+                });
+        },
+
         // Method to create an LTI developer key
         createLtiDeveloperKey: async (developerKeyBody) => {
 
@@ -192,6 +213,18 @@ export default function create(canvasUrl, canvasToken) {
                 }
             }
             return loadBatch(`${canvasUrl}${getLtiToolUrl}`);
+        },
+
+        getLtiRegistrationByClientId: async (clientId) => {
+            const getLtiRegistrationUrl = CANVAS_GET_LTI_REGISTRATION_BY_CLIENT_ID.replace(DEV_KEY, clientId);
+
+            try {
+                const response = await axios.get(`${canvasUrl}${getLtiRegistrationUrl}`, REQUEST_CONFIG);
+                return response.data;
+            } catch (error) {
+                checkError(error)
+                throw new Error(`Error getting LTI registration for client ID ${clientId}: ${error}`);
+            }
         },
 
         // Method to add the created LTI tool to the supplied subaccount.

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -117,14 +117,18 @@ export default function create(canvasUrl, canvasToken) {
             };
 
             // Unlock the LTI registration
-            return await axios.put(`${canvasUrl}${updateLtiRegistrationUrl}`, unlockBody, REQUEST_CONFIG)
-                .then(function (response) {
-                    return response.data;
+            try {
+                const response = await requestJson({
+                    url: `${canvasUrl}${updateLtiRegistrationUrl}`,
+                    method: 'PUT',
+                    headers: REQUEST_CONFIG.headers,
+                    body: unlockBody
                 })
-                .catch(function (error) {
-                    checkError(error)
-                    throw error;
-                });
+                return response.data
+            } catch (error) {
+                checkError(error)
+                throw new Error(`Error unlocking LTI registration ${ltiRegistrationId}: ${error}`);
+            }
         },
 
         // Method to create an LTI developer key
@@ -219,8 +223,12 @@ export default function create(canvasUrl, canvasToken) {
             const getLtiRegistrationUrl = CANVAS_GET_LTI_REGISTRATION_BY_CLIENT_ID.replace(DEV_KEY, clientId);
 
             try {
-                const response = await axios.get(`${canvasUrl}${getLtiRegistrationUrl}`, REQUEST_CONFIG);
-                return response.data;
+                const response = await requestJson({
+                    url: `${canvasUrl}${getLtiRegistrationUrl}`,
+                    method: 'GET',
+                    headers: REQUEST_CONFIG.headers
+                })
+                return response.data
             } catch (error) {
                 checkError(error)
                 throw new Error(`Error getting LTI registration for client ID ${clientId}: ${error}`);


### PR DESCRIPTION
When adding a tool to sub-account unlock the LTI tool registration first.
[AB#126668](https://dev.azure.com/oxforduniversity/a2417215-bc45-4732-9067-4006e8242f57/_workitems/edit/126668)